### PR TITLE
Update input.py; Add cut_off and coulomb_type parameters

### DIFF
--- a/mmic_optim/components/dummy_component.py
+++ b/mmic_optim/components/dummy_component.py
@@ -1,13 +1,13 @@
 from ..models.input import OptimInput
 from ..models.output import OptimOutput
-from mmic.components.blueprints import SpecificComponent
+from mmic.components.blueprints import GenericComponent
 from typing import List, Tuple, Optional, Set
 
 
 __all__ = ["OptimDummyComponent"]
 
 
-class OptimDummyComponent(SpecificComponent):
+class OptimDummyComponent(GenericComponent):
     """
     A sample component that does nothing interesting. Follow the same structure
     to develop your own optim component. You can attach any helper method to this

--- a/mmic_optim/models/input.py
+++ b/mmic_optim/models/input.py
@@ -56,7 +56,15 @@ class OptimInput(ProcInput):
         None,
         description="Optimization method to use e.g. conjugate_gradient.",
     )
-
+    cut_off: str = Field(
+        None,
+        description="Neighbor searching algorithm"
+    )
+    coulomb_type str = Field(
+        None,
+        description="Algorithm used to deal with long-range interaction"
+    )
+    
     # Geometric constraint fields
     bond_const: Optional[Dict[str, List[int]]] = Field(
         None,

--- a/mmic_optim/models/input.py
+++ b/mmic_optim/models/input.py
@@ -23,7 +23,7 @@ class OptimInput(ProcInput):
         None,
         description="Cell dimensions in the form: ((xmin, ymin, ...), (xmax, ymax, ...))",
     )
-    boundary: Tuple[str] = Field(
+    boundary: Tuple[str, str, str] = Field(
         None,
         description="Boundary conditions in all dimensions e.g. (periodic, periodic, periodic) imposes periodic boundaries in 3D.",
     )

--- a/mmic_optim/models/input.py
+++ b/mmic_optim/models/input.py
@@ -64,6 +64,7 @@ class OptimInput(ProcInput):
         None,
         description="Algorithm used to deal with long-range interaction"
     )
+    # Coulomb_type and cut_off variables should be replaced by more general variables such as 'long_range_force'
     
     # Geometric constraint fields
     bond_const: Optional[Dict[str, List[int]]] = Field(

--- a/mmic_optim/models/input.py
+++ b/mmic_optim/models/input.py
@@ -60,7 +60,7 @@ class OptimInput(ProcInput):
         None,
         description="Neighbor searching algorithm"
     )
-    coulomb_type str = Field(
+    coulomb_type: str = Field(
         None,
         description="Algorithm used to deal with long-range interaction"
     )


### PR DESCRIPTION
added cut_off and coulomb_type

## Description
Add two parameters:cut_off and coulomb_type parameters. Therefore enables users to set them when constructing a .mdp file.

## Todos
-  Add two parameters:cut_off and coulomb_type parameters.

## Questions
- [ ] More parameters may need to be added in the future.

## Status
- Ready to go